### PR TITLE
WPW-26: donet - Implement call to shutdown

### DIFF
--- a/Worldpay.Within.Rpc/Worldpay/Innovation/WPWithin/Rpc/Types/ServiceMessage.cs
+++ b/Worldpay.Within.Rpc/Worldpay/Innovation/WPWithin/Rpc/Types/ServiceMessage.cs
@@ -36,6 +36,8 @@ namespace Worldpay.Innovation.WPWithin.Rpc.Types
 
     public string Scheme { get; set; }
 
+    public string DeviceName { get; set; }
+
     public ServiceMessage() {
     }
 
@@ -92,6 +94,13 @@ namespace Worldpay.Innovation.WPWithin.Rpc.Types
             case 6:
               if (field.Type == TType.String) {
                 Scheme = iprot.ReadString();
+              } else { 
+                TProtocolUtil.Skip(iprot, field.Type);
+              }
+              break;
+            case 7:
+              if (field.Type == TType.String) {
+                DeviceName = iprot.ReadString();
               } else { 
                 TProtocolUtil.Skip(iprot, field.Type);
               }
@@ -165,6 +174,14 @@ namespace Worldpay.Innovation.WPWithin.Rpc.Types
           oprot.WriteString(Scheme);
           oprot.WriteFieldEnd();
         }
+        if (DeviceName != null) {
+          field.Name = "deviceName";
+          field.Type = TType.String;
+          field.ID = 7;
+          oprot.WriteFieldBegin(field);
+          oprot.WriteString(DeviceName);
+          oprot.WriteFieldEnd();
+        }
         oprot.WriteFieldStop();
         oprot.WriteStructEnd();
       }
@@ -212,6 +229,12 @@ namespace Worldpay.Innovation.WPWithin.Rpc.Types
         __first = false;
         __sb.Append("Scheme: ");
         __sb.Append(Scheme);
+      }
+      if (DeviceName != null) {
+        if(!__first) { __sb.Append(", "); }
+        __first = false;
+        __sb.Append("DeviceName: ");
+        __sb.Append(DeviceName);
       }
       __sb.Append(")");
       return __sb.ToString();

--- a/Worldpay.Within.Rpc/Worldpay/Innovation/WPWithin/Rpc/WPWithin.cs
+++ b/Worldpay.Within.Rpc/Worldpay/Innovation/WPWithin/Rpc/WPWithin.cs
@@ -37,6 +37,7 @@ namespace Worldpay.Innovation.WPWithin.Rpc
       Worldpay.Innovation.WPWithin.Rpc.Types.PaymentResponse makePayment(Worldpay.Innovation.WPWithin.Rpc.Types.TotalPriceResponse request);
       Worldpay.Innovation.WPWithin.Rpc.Types.ServiceDeliveryToken beginServiceDelivery(int serviceID, Worldpay.Innovation.WPWithin.Rpc.Types.ServiceDeliveryToken serviceDeliveryToken, int unitsToSupply);
       Worldpay.Innovation.WPWithin.Rpc.Types.ServiceDeliveryToken endServiceDelivery(int serviceID, Worldpay.Innovation.WPWithin.Rpc.Types.ServiceDeliveryToken serviceDeliveryToken, int unitsReceived);
+      void CloseRPCAgent();
     }
 
     /// <summary>
@@ -102,6 +103,10 @@ namespace Worldpay.Innovation.WPWithin.Rpc
       #if SILVERLIGHT
       IAsyncResult Begin_endServiceDelivery(AsyncCallback callback, object state, int serviceID, Worldpay.Innovation.WPWithin.Rpc.Types.ServiceDeliveryToken serviceDeliveryToken, int unitsReceived);
       Worldpay.Innovation.WPWithin.Rpc.Types.ServiceDeliveryToken End_endServiceDelivery(IAsyncResult asyncResult);
+      #endif
+      #if SILVERLIGHT
+      IAsyncResult Begin_CloseRPCAgent(AsyncCallback callback, object state);
+      void End_CloseRPCAgent(IAsyncResult asyncResult);
       #endif
     }
 
@@ -1125,6 +1130,64 @@ namespace Worldpay.Innovation.WPWithin.Rpc
         throw new TApplicationException(TApplicationException.ExceptionType.MissingResult, "endServiceDelivery failed: unknown result");
       }
 
+      
+      #if SILVERLIGHT
+      public IAsyncResult Begin_CloseRPCAgent(AsyncCallback callback, object state)
+      {
+        return send_CloseRPCAgent(callback, state);
+      }
+
+      public void End_CloseRPCAgent(IAsyncResult asyncResult)
+      {
+        oprot_.Transport.EndFlush(asyncResult);
+        recv_CloseRPCAgent();
+      }
+
+      #endif
+
+      public void CloseRPCAgent()
+      {
+        #if !SILVERLIGHT
+        send_CloseRPCAgent();
+        recv_CloseRPCAgent();
+
+        #else
+        var asyncResult = Begin_CloseRPCAgent(null, null);
+        End_CloseRPCAgent(asyncResult);
+
+        #endif
+      }
+      #if SILVERLIGHT
+      public IAsyncResult send_CloseRPCAgent(AsyncCallback callback, object state)
+      #else
+      public void send_CloseRPCAgent()
+      #endif
+      {
+        oprot_.WriteMessageBegin(new TMessage("CloseRPCAgent", TMessageType.Call, seqid_));
+        CloseRPCAgent_args args = new CloseRPCAgent_args();
+        args.Write(oprot_);
+        oprot_.WriteMessageEnd();
+        #if SILVERLIGHT
+        return oprot_.Transport.BeginFlush(callback, state);
+        #else
+        oprot_.Transport.Flush();
+        #endif
+      }
+
+      public void recv_CloseRPCAgent()
+      {
+        TMessage msg = iprot_.ReadMessageBegin();
+        if (msg.Type == TMessageType.Exception) {
+          TApplicationException x = TApplicationException.Read(iprot_);
+          iprot_.ReadMessageEnd();
+          throw x;
+        }
+        CloseRPCAgent_result result = new CloseRPCAgent_result();
+        result.Read(iprot_);
+        iprot_.ReadMessageEnd();
+        return;
+      }
+
     }
     public class Processor : TProcessor {
       public Processor(ISync iface)
@@ -1145,6 +1208,7 @@ namespace Worldpay.Innovation.WPWithin.Rpc
         processMap_["makePayment"] = makePayment_Process;
         processMap_["beginServiceDelivery"] = beginServiceDelivery_Process;
         processMap_["endServiceDelivery"] = endServiceDelivery_Process;
+        processMap_["CloseRPCAgent"] = CloseRPCAgent_Process;
       }
 
       protected delegate void ProcessFunction(int seqid, TProtocol iprot, TProtocol oprot);
@@ -1689,6 +1753,34 @@ namespace Worldpay.Innovation.WPWithin.Rpc
           Console.Error.WriteLine(ex.ToString());
           TApplicationException x = new TApplicationException        (TApplicationException.ExceptionType.InternalError," Internal error.");
           oprot.WriteMessageBegin(new TMessage("endServiceDelivery", TMessageType.Exception, seqid));
+          x.Write(oprot);
+        }
+        oprot.WriteMessageEnd();
+        oprot.Transport.Flush();
+      }
+
+      public void CloseRPCAgent_Process(int seqid, TProtocol iprot, TProtocol oprot)
+      {
+        CloseRPCAgent_args args = new CloseRPCAgent_args();
+        args.Read(iprot);
+        iprot.ReadMessageEnd();
+        CloseRPCAgent_result result = new CloseRPCAgent_result();
+        try
+        {
+          iface_.CloseRPCAgent();
+          oprot.WriteMessageBegin(new TMessage("CloseRPCAgent", TMessageType.Reply, seqid)); 
+          result.Write(oprot);
+        }
+        catch (TTransportException)
+        {
+          throw;
+        }
+        catch (Exception ex)
+        {
+          Console.Error.WriteLine("Error occurred in processor:");
+          Console.Error.WriteLine(ex.ToString());
+          TApplicationException x = new TApplicationException        (TApplicationException.ExceptionType.InternalError," Internal error.");
+          oprot.WriteMessageBegin(new TMessage("CloseRPCAgent", TMessageType.Exception, seqid));
           x.Write(oprot);
         }
         oprot.WriteMessageEnd();
@@ -4813,6 +4905,131 @@ namespace Worldpay.Innovation.WPWithin.Rpc
           __sb.Append("Err: ");
           __sb.Append(Err== null ? "<null>" : Err.ToString());
         }
+        __sb.Append(")");
+        return __sb.ToString();
+      }
+
+    }
+
+
+    #if !SILVERLIGHT
+    [Serializable]
+    #endif
+    public partial class CloseRPCAgent_args : TBase
+    {
+
+      public CloseRPCAgent_args() {
+      }
+
+      public void Read (TProtocol iprot)
+      {
+        iprot.IncrementRecursionDepth();
+        try
+        {
+          TField field;
+          iprot.ReadStructBegin();
+          while (true)
+          {
+            field = iprot.ReadFieldBegin();
+            if (field.Type == TType.Stop) { 
+              break;
+            }
+            switch (field.ID)
+            {
+              default: 
+                TProtocolUtil.Skip(iprot, field.Type);
+                break;
+            }
+            iprot.ReadFieldEnd();
+          }
+          iprot.ReadStructEnd();
+        }
+        finally
+        {
+          iprot.DecrementRecursionDepth();
+        }
+      }
+
+      public void Write(TProtocol oprot) {
+        oprot.IncrementRecursionDepth();
+        try
+        {
+          TStruct struc = new TStruct("CloseRPCAgent_args");
+          oprot.WriteStructBegin(struc);
+          oprot.WriteFieldStop();
+          oprot.WriteStructEnd();
+        }
+        finally
+        {
+          oprot.DecrementRecursionDepth();
+        }
+      }
+
+      public override string ToString() {
+        StringBuilder __sb = new StringBuilder("CloseRPCAgent_args(");
+        __sb.Append(")");
+        return __sb.ToString();
+      }
+
+    }
+
+
+    #if !SILVERLIGHT
+    [Serializable]
+    #endif
+    public partial class CloseRPCAgent_result : TBase
+    {
+
+      public CloseRPCAgent_result() {
+      }
+
+      public void Read (TProtocol iprot)
+      {
+        iprot.IncrementRecursionDepth();
+        try
+        {
+          TField field;
+          iprot.ReadStructBegin();
+          while (true)
+          {
+            field = iprot.ReadFieldBegin();
+            if (field.Type == TType.Stop) { 
+              break;
+            }
+            switch (field.ID)
+            {
+              default: 
+                TProtocolUtil.Skip(iprot, field.Type);
+                break;
+            }
+            iprot.ReadFieldEnd();
+          }
+          iprot.ReadStructEnd();
+        }
+        finally
+        {
+          iprot.DecrementRecursionDepth();
+        }
+      }
+
+      public void Write(TProtocol oprot) {
+        oprot.IncrementRecursionDepth();
+        try
+        {
+          TStruct struc = new TStruct("CloseRPCAgent_result");
+          oprot.WriteStructBegin(struc);
+
+          oprot.WriteFieldStop();
+          oprot.WriteStructEnd();
+        }
+        finally
+        {
+          oprot.DecrementRecursionDepth();
+        }
+      }
+
+      public override string ToString() {
+        StringBuilder __sb = new StringBuilder("CloseRPCAgent_result(");
         __sb.Append(")");
         return __sb.ToString();
       }

--- a/Worldpay.Within.Sample/Commands/CommandMenu.cs
+++ b/Worldpay.Within.Sample/Commands/CommandMenu.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using Worldpay.Innovation.WPWithin.AgentManager;
 using Worldpay.Innovation.WPWithin.ThriftAdapters;
 
@@ -19,10 +20,9 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
         private readonly List<Command> _menuItems;
         private readonly TextWriter _output;
         private readonly TextReader _reader;
-        private RpcAgentManager _rpcManager;
+
         private SimpleProducer _simpleProducer;
-        private readonly RpcAgentConfiguration _defaultAgentConfig;
-        private WPWithinService _service;
+        private SimpleConsumer _simpleConsumer;
 
         public CommandMenu()
         {
@@ -30,30 +30,26 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
             {
                 new Command("Exit", "Exits the application.", (a) =>
                 {
+                    try {
+                        _simpleProducer?.StopRpcClient();
+                    }
+                    catch { /* ignore */ }
                     _output.WriteLine("Exiting");
                     return CommandResult.Exit;
                 }),
-                new Command("StartRPCClient", "Starts a default Thrift RPC agent", StartRpcClient),
-                new Command("StopRPCClient", "Stops the default Thrift RPC agent", StopRpcClient),
+                //new Command("StartRPCClient", "Starts a default Thrift RPC agent", StartRpcClient),
+                //new Command("StopRPCClient", "Stops the default Thrift RPC agent", StopRpcClient),
                 new Command("StartSimpleProducer", "Starts a simple producer", StartSimpleProducer),
                 new Command("StopSimpleProducer", "Starts a simple producer", StopSimpleProducer),
                 new Command("ConsumePurchase", "Consumes a service (first price of first service found)", ConsumePurchase),
                 new Command("FindProducers", "Lists out all the producers that could be found", FindProducers),
-                new Command("ShowRpcAgentPath", "Shows where the RPC Agent has been found.", FindRpcAgent), 
+                new Command("ShowRpcAgentPath", "Shows where the RPC Agent has been found.", FindRpcAgent),
             });
 
             // TODO Parameterise these so output can be written to a specific file
             _output = Console.Out;
             _error = Console.Error;
             _reader = Console.In;
-            _defaultAgentConfig = new RpcAgentConfiguration
-            {
-                ServicePort = 9091,
-                CallbackPort = 9092,
-                LogLevel = "panic,fatal,error,warn,info,debug",
-                LogFile = new FileInfo("wpwithin.log"),
-
-            };
         }
 
         private CommandResult FindRpcAgent(string[] arg)
@@ -73,6 +69,7 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
 
         private CommandResult FindProducers(string[] arg)
         {
+            WPWithinService service = null;
             RpcAgentConfiguration consumerConfig = new RpcAgentConfiguration
             {
                 LogLevel = "panic,fatal,error,warn,info,debug",
@@ -83,7 +80,7 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
             consumerAgent.StartThriftRpcAgentProcess();
             try
             {
-                WPWithinService service = new WPWithinService(consumerConfig);
+                service = new WPWithinService(consumerConfig);
                 service.SetupDevice("Scanner", $".NET Sample Producer scanner running on ${Dns.GetHostName()}");
                 List<ServiceMessage> devices = service.DeviceDiscovery(10000).ToList();
 
@@ -96,7 +93,7 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
                     _output.WriteLine($"\tDescription: {device.DeviceDescription}, URL Prefix: {device.UrlPrefix}");
                     service.InitConsumer("http://", device.Hostname, device.PortNumber ?? 80, device.UrlPrefix,
                         device.ServerId,
-                        new HceCard("Bilbo", "Baggins", "Card", "5555555555554444", 11, 2018, "113"), 
+                        new HceCard("Bilbo", "Baggins", "Card", "5555555555554444", 11, 2018, "113"),
                         new PspConfig());
                     try
                     {
@@ -121,10 +118,14 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
             }
             finally
             {
+                try
+                {
+                    service?.CloseRPCAgent();
+                }
+                catch { }
                 consumerAgent.StopThriftRpcAgentProcess();
             }
             return CommandResult.Success;
-
         }
 
         private CommandResult ConsumePurchase(string[] arg)
@@ -137,12 +138,25 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
             };
             RpcAgentManager consumerAgent = new RpcAgentManager(consumerConfig);
             consumerAgent.StartThriftRpcAgentProcess();
+            // do we need to wait a little to allow RPC Agent to start ?
+            // Thread.Sleep(250);
 
             WPWithinService service = new WPWithinService(consumerConfig);
-            SimpleConsumer consumer = new SimpleConsumer(_output, _error);
-            consumer.MakePurchase(service);
-
-            consumerAgent.StopThriftRpcAgentProcess();
+            try
+            {
+                _simpleConsumer = new SimpleConsumer(_output, _error, consumerAgent);
+                _simpleConsumer.MakePurchase(service);
+            }
+            catch
+            {
+                // rethrow, but run finally section first to stop rpc client if required
+                throw;
+            }
+            finally
+            {
+                _simpleConsumer?.StopRpcClient();
+                _simpleConsumer = null;
+            }
             return CommandResult.Success;
         }
 
@@ -153,7 +167,18 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
                 _output.WriteLine("Simple producer already started, stop it before trying to start it again.");
                 return CommandResult.NonCriticalError;
             }
-            _simpleProducer = new SimpleProducer(_output, _error, _service);
+
+            RpcAgentConfiguration rpcAgentConf = new RpcAgentConfiguration
+            {
+                ServicePort = 9091,
+                CallbackPort = 9092,
+                LogLevel = "panic,fatal,error,warn,info,debug",
+                LogFile = new FileInfo("wpwithin.log"),
+            };
+            RpcAgentManager rpcAgentMgr = new RpcAgentManager(rpcAgentConf);
+            rpcAgentMgr.StartThriftRpcAgentProcess();
+            Thread.Sleep(750);
+            _simpleProducer = new SimpleProducer(_output, _error, new WPWithinService(rpcAgentConf), rpcAgentMgr);
             _simpleProducer.Start();
             return CommandResult.Success;
         }
@@ -170,34 +195,10 @@ namespace Worldpay.Innovation.WPWithin.Sample.Commands
             return CommandResult.Success;
         }
 
-        private CommandResult StopRpcClient(string[] arg)
+        internal void TerminateChilds()
         {
-            if (_rpcManager == null)
-            {
-                _error.WriteLine("Thift RPC Agent not active.  Start it before trying to stop it.");
-                return CommandResult.NonCriticalError;
-            }
-            _service.Dispose();
-            _service = null;
-            _rpcManager.StopThriftRpcAgentProcess();
-            _rpcManager = null;
-            return CommandResult.Success;
-        }
-
-        private CommandResult StartRpcClient(string[] arg)
-        {
-            if (_rpcManager != null)
-            {
-                _error.WriteLine("Thrift RPC Agent already active.  Stop it before trying to start a new one");
-                return CommandResult.NonCriticalError;
-            }
-            _rpcManager = new RpcAgentManager(new RpcAgentConfiguration
-            {
-                LogLevel = RpcAgentConfiguration.LogLevelAll
-            });
-            _rpcManager.StartThriftRpcAgentProcess();
-            _service = new WPWithinService(_defaultAgentConfig);
-            return CommandResult.Success;
+            _simpleConsumer?.StopRpcClient();
+            _simpleProducer?.StopRpcClient();
         }
 
         internal CommandResult ReadEvalPrint(string[] args)

--- a/Worldpay.Within.Sample/Program.cs
+++ b/Worldpay.Within.Sample/Program.cs
@@ -1,9 +1,15 @@
 ﻿using Worldpay.Innovation.WPWithin.Sample.Commands;
 
+using System;
+using System.Runtime.InteropServices;
+
 namespace Worldpay.Innovation.WPWithin.Sample
 {
     internal class Program
     {
+        private static CommandMenu menu;
+
+
         private static void Main(string[] args)
         {
             new Program().Run(args);
@@ -11,12 +17,39 @@ namespace Worldpay.Innovation.WPWithin.Sample
 
         private void Run(string[] args)
         {
-            CommandMenu menu = new CommandMenu();
+            // managing process shutdown
+            handler = new ConsoleEventDelegate(ConsoleEventCallback);
+            SetConsoleCtrlHandler(handler, true);
+
+            menu = new CommandMenu();
             CommandResult result = CommandResult.NoOp;
             while (result != CommandResult.CriticalError && result != CommandResult.Exit)
             {
                 result = menu.ReadEvalPrint(args);
             }
         }
+
+#region Managing Process shutdown gracefully (Ctrl+C instead of kill)
+
+        static ConsoleEventDelegate handler;   // Keeps it from getting garbage collected
+        private delegate bool ConsoleEventDelegate(int eventType);
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool SetConsoleCtrlHandler(ConsoleEventDelegate callback, bool add);
+
+
+        static bool ConsoleEventCallback(int eventType)
+        {
+            if (eventType == 2)
+            {
+                Console.WriteLine("Console window closing.");
+                if (menu != null)
+                {
+                    menu.TerminateChilds();
+                }
+            }
+            return false;
+        }
+
+#endregion
     }
 }

--- a/Worldpay.Within/AgentManager/RpcAgentManager.cs
+++ b/Worldpay.Within/AgentManager/RpcAgentManager.cs
@@ -137,15 +137,31 @@ namespace Worldpay.Innovation.WPWithin.AgentManager
 
             if (_thriftRpcProcess.HasExited)
             {
-                Log.Warn("Ignoring call to stop Thrift RPC agent as the process has already exited");
+                Log.Debug("Ignoring call to stop Thrift RPC agent as the process has already exited");
             }
             else
             {
+                try
+                {
+                    _thriftRpcProcess.CloseMainWindow();
+                }
+                catch (WPWithinException wpwe)
+                {
+                    Log.Debug("Expected WPWithin exception from closing RPC agent: " + wpwe.Message);
+                }
+                catch(Exception e)
+                {
+                    Log.Debug("Expected exception from closing RPC agent: " + e.Message);
+                }
                 // BUG Commented out Ctrl-C style kill code as it won't work if in a Console app, will re-enable once I've fixed it properly
                 //                if (!SentCtrlCToProcess(_thriftRpcProcess))
                 //                {
-                Log.Info("Unable to gracefully stop Thift RPC Agent, issuing kill instead");
-                _thriftRpcProcess.Kill();
+                
+                if (!_thriftRpcProcess.HasExited)
+                {
+                    Log.Info("Unable to gracefully stop Thift RPC Agent, issuing kill instead");
+                    _thriftRpcProcess.Kill();
+                }
                 //                }
             }
         }

--- a/Worldpay.Within/WPWithinService.cs
+++ b/Worldpay.Within/WPWithinService.cs
@@ -315,6 +315,22 @@ namespace Worldpay.Innovation.WPWithin
             }
         }
 
+        public void CloseRPCAgent()
+        {
+            try
+            {
+                _client.CloseRPCAgent();
+            }
+            catch(TApplicationException tae)
+            {
+                throw new WPWithinException(tae);
+            }
+            catch(Exception e)
+            {
+                throw new WPWithinException(e.Message);
+            }
+        }
+
         private void InitClient(RpcAgentConfiguration config)
         {
             TTransport transport = config.GetThriftTransport();


### PR DESCRIPTION
changes:
- support for new thrift function CloseRPCAgent() 
- removed two menus related to start/stop RPC agent separately (now the agent is started when producer is started and stopped when producer is stopped).
- killing RPC agents for scenario through the X window kill
